### PR TITLE
Compass sensor alignment

### DIFF
--- a/Source/AntTrack/AntTrack.ino
+++ b/Source/AntTrack/AntTrack.ino
@@ -134,7 +134,19 @@
     
    typedef enum frport_type_set { f_none = 0, f_port1 = 1, f_port2 = 2, s_port = 3, f_auto = 4} frport_t;  
 
-   typedef enum polarity_set { idle_low = 0, idle_high = 1, no_traffic = 2 } pol_t;    
+   typedef enum polarity_set { idle_low = 0, idle_high = 1, no_traffic = 2 } pol_t;
+
+   typedef enum Compass_Align {
+      ALIGN_DEFAULT = 0,
+      CW0_DEG = 1,
+      CW90_DEG = 2,
+      CW180_DEG = 3,
+      CW270_DEG = 4,
+      CW0_DEG_FLIP = 5,
+      CW90_DEG_FLIP = 6,
+      CW180_DEG_FLIP = 7,
+      CW270_DEG_FLIP = 8
+    };
     
     // Protocol determination
     uint32_t inBaud = 0;    // Includes flight GPS
@@ -597,7 +609,13 @@ void setup() {
   #if (Heading_Source == 4)  // Tracker box  
 
     #if ( (defined ESP8266) || (defined ESP32) )
-      gpsBaud = getBaud(gps_rxPin);
+      
+      #if defined Box_GPS_Baud 
+        gpsBaud = Box_GPS_Baud;
+      #else
+        gpsBaud = getBaud(gps_rxPin);
+      #endif
+
       Log.printf("Tracker box GPS baud rate detected is %db/s\n", gpsBaud);       
       String s_baud=String(gpsBaud);   // integer to string. "String" overloaded
       LogScreenPrintln("Box GPS at "+ s_baud);

--- a/Source/AntTrack/Utilities.ino
+++ b/Source/AntTrack/Utilities.ino
@@ -1549,4 +1549,47 @@ void WiFiEventHandler(WiFiEvent_t event)  {
      if (ang < 0) ang += 360;
      if (ang > 359) ang -= 360;
      return ang;
-   }     
+   }
+   
+  //================================================================================================= 
+  //                              S E N S O R    A L I G N M E N T
+  //=================================================================================================
+  // params: 
+  // int val -> angle value in degrees
+  // unit8_t rotation -> rotation enum definition value, fe CW180_DEG
+  int applySensorAlignment(int val, uint8_t rotation) {
+    int res = 0;
+    
+    switch (rotation) {
+    default:
+    case CW0_DEG:
+    case ALIGN_DEFAULT:
+    case CW180_DEG_FLIP:
+        res = val;
+        break;
+    case CW90_DEG:
+        res = val + 90;
+        break;
+    case CW180_DEG:
+        res = val + 180;
+        break;
+    case CW270_DEG:
+        res = val + 270;
+        break;
+    case CW0_DEG_FLIP:
+        res = val + 180;
+        break;
+    case CW90_DEG_FLIP:
+        res = val + 270;
+        break;
+    case CW270_DEG_FLIP:
+        res = val + 90;
+        break;
+    }
+    
+    if (res > 360) {
+      res = res - 360;
+    }
+
+    return  res;
+  }

--- a/Source/AntTrack/config.h
+++ b/Source/AntTrack/config.h
@@ -70,9 +70,22 @@ v2.19.7             Add climb
 //#define Heading_Source  2     // 2=Flight Computer Compass
 #define Heading_Source  3     // 3=Trackerbox_Compass 
 //#define Heading_Source  4     // 4=Trackerbox_GPS_And_Compass
+// Select GPS module serial link speed. Many GPS modules are capable of using multiple serial speed out from the box.
+// This information should be provided by the manufacturer.
+// If not defined, speed will be selected automatically.
+// #define Box_GPS_Baud 9600
 
-//#define HMC5883L            // Select compass type
+// Select compass type. This information should be provided by the manufacturer.
+//#define HMC5883L
 #define QMC5883L
+
+// Select compass declination. Consult http://www.magnetic-declination.com/  to check your zone declination value.
+//#define Compass_Declination -0.34
+
+// Select compass orientation. Many of the available GPS/Compass boards have their compass oriented in non-standart way,
+// the correct re-orientation information should be provided by the manufacturer.
+// Available options: ALIGN_DEFAULT, CW0_DEG, CW90_DEG, CW180_DEG, CW270_DEG, CW0_DEG_FLIP, CW90_DEG_FLIP, CW180_DEG_FLIP, CW270_DEG_FLIP
+//#define Compass_Rotation CW270_DEG_FLIP
 
 // If the tracker box has a GPS AND a compass attached, we support a moving tracker. For example,
 // the tracker could be on one moving vehicle and track a second moving vehicle, or a 'plane could 


### PR DESCRIPTION
- Added "Utilities.applySensorAlignment"  function to rotate angle based sensor value to pre-defined options : ALIGN_DEFAULT, CW0_DEG, CW90_DEG, CW180_DEG, CW270_DEG, CW0_DEG_FLIP, CW90_DEG_FLIP, CW180_DEG_FLIP, CW270_DEG_FLIP
- If "Compass_Rotation" is defined in config, rotation is applied to it's value on the "Compass.getTrackerboxHeading" output.
- Misc; Compass_Declination can be defined in config.
- Misc; "Box_GPS_Baud" rate can be defined in config.