### PR TITLE
Update AntTrack.ino

### DIFF
--- a/source/stable/v2.20.06/AntTrack/AntTrack.ino
+++ b/source/stable/v2.20.06/AntTrack/AntTrack.ino
@@ -128,7 +128,8 @@
 #include <ardupilotmega/ardupilotmega.h>
 
 #if (PROTOCOL == 9)
-  CRSF   crsf;          // instantiate crsf object
+ #include <terseCRSF.h>  
+ CRSF   crsf;          // instantiate crsf object
 #endif
 
    String    pgm_path;


### PR DESCRIPTION
If Protocol 9 is selected, include the crossfire lib. It fails a compile otherwise